### PR TITLE
Add tappable hotspots on map

### DIFF
--- a/GeoNewsFinder4/package-lock.json
+++ b/GeoNewsFinder4/package-lock.json
@@ -15,6 +15,7 @@
         "@react-navigation/stack": "^6.3.20",
         "expo": "~49.0.15",
         "expo-status-bar": "~1.6.0",
+        "geolib": "^3.3.4",
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-native": "0.72.6",
@@ -10221,6 +10222,11 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/geolib": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/geolib/-/geolib-3.3.4.tgz",
+      "integrity": "sha512-EicrlLLL3S42gE9/wde+11uiaYAaeSVDwCUIv2uMIoRBfNJCn8EsSI+6nS3r4TCKDO6+RQNM9ayLq2at+oZQWQ=="
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",

--- a/GeoNewsFinder4/package.json
+++ b/GeoNewsFinder4/package.json
@@ -16,6 +16,7 @@
     "@react-navigation/stack": "^6.3.20",
     "expo": "~49.0.15",
     "expo-status-bar": "~1.6.0",
+    "geolib": "^3.3.4",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-native": "0.72.6",

--- a/GeoNewsFinder4/screens/MapViewScreen.js
+++ b/GeoNewsFinder4/screens/MapViewScreen.js
@@ -8,8 +8,8 @@ import BottomSheet from '../components/BottomSheet';
 
 const PROVIDER_GOOGLE = 'google';
 
-const { width:deviceWidth, height:deviceHeight } = Dimensions.get('window');
-const ASPECT_RATIO = deviceWidth / deviceHeight;
+const { width:DEVICE_WIDTH, height:DEVICE_HEIGHT } = Dimensions.get('window');
+const ASPECT_RATIO = DEVICE_WIDTH / DEVICE_HEIGHT;
 
 const INITIAL_LOCATION = {
   latitude: 26.385784,  

--- a/GeoNewsFinder4/screens/MapViewScreen.js
+++ b/GeoNewsFinder4/screens/MapViewScreen.js
@@ -1,15 +1,21 @@
 import React, { useState } from 'react';
-import { View, StyleSheet, Button, Modal } from 'react-native';
+import { View, StyleSheet, Button, Modal, Dimensions } from 'react-native';
+import { Circle } from 'react-native-maps';
+import { getDistance } from 'geolib';
 import MapView from '../components/MapView';
 import BottomSheet from '../components/BottomSheet'; 
 
 
 const PROVIDER_GOOGLE = 'google';
+
+const { width:deviceWidth, height:deviceHeight } = Dimensions.get('window');
+const ASPECT_RATIO = deviceWidth / deviceHeight;
+
 const INITIAL_LOCATION = {
-  latitude: 34.413,
-  longitude: -119.86,
-  latitudeDelta: 0.0922,
-  longitudeDelta: 0.0421
+  latitude: 26.385784,  
+  longitude: -98.8280,
+  latitudeDelta: 90,
+  longitudeDelta: 90 * ASPECT_RATIO
 }  
 
 
@@ -17,17 +23,73 @@ const INITIAL_LOCATION = {
 const MapViewScreen = () => {
   const [isModalVisible, setModalVisible] = useState(false);
 
+  const [hotspots, setHotspots] = useState([
+    {
+      _id: 'san diego',
+      radius: 200 * 1000, // radius parameters are in meters.
+      strokeWidth: 2,
+      latitude: 34.413,
+      longitude: -119.86
+    },
+    {
+      _id: 'nyc',
+      radius: 300 * 1000,
+      strokeWidth: 2,
+      latitude: 40.7486,
+      longitude: -73.986
+    },
+    {
+      _id: 'houston',
+      radius: 400 * 1000,
+      strokeWidth: 2,
+      latitude: 30.092,
+      longitude: -95.346
+    }
+  ]);
+
   const toggleModal = () => {
     setModalVisible(!isModalVisible);
-
   };
+
   return (
     <View style={styles.container}>
-      <MapView style={styles.map} defaultZoom={15} provider={PROVIDER_GOOGLE} region={INITIAL_LOCATION} />
+      <MapView 
+        style={styles.map} 
+        provider={PROVIDER_GOOGLE} 
+        region={INITIAL_LOCATION}
+        onPress={(event) => {
+          const coordinates = event.nativeEvent.coordinate;
 
-      <View style={styles.buttonContainer}>
-        <Button title="This is a hotspot" onPress={toggleModal} />
-      </View>
+          // onPress for hot spots
+          // Workaround from issue where MapView.Circle cannot use onPress prop: 
+          //    https://github.com/react-native-maps/react-native-maps/issues/1409
+          hotspots.map(hotspot => {
+              const distance = getDistance(
+                  { latitude: coordinates.latitude, longitude: coordinates.longitude },
+                  { latitude: hotspot.latitude, longitude: hotspot.longitude }
+              );
+  
+              if (distance <= hotspot.radius) {
+                toggleModal();
+              }
+          })
+      }}
+      >
+        {hotspots.map(hotspot => (
+            <Circle  
+              key={hotspot._id}
+              center={{
+                latitude: hotspot.latitude,
+                longitude: hotspot.longitude
+              }}
+              radius={ hotspot.radius }
+              strokeWidth={ hotspot.strokeWidth }
+              strokeColor='rgba(255, 0, 0, 0.4)'
+              fillColor='rgba(255, 0, 0, 0.4)'
+            />
+        ))
+        }
+      </MapView>
 
       <Modal
         transparent={true}


### PR DESCRIPTION
https://trello.com/c/sLALQVD1

# Overview

This PR adds a rudimentary version of adding hotspots onto the map for our MVP. This PR is able to

- Create hot spots with a unique ID, radius, etc.
- Hotspots are tappable. In this PR, the hotspots reveal a modal (meant for showing news pertaining to the specific hot spot)

I also adjusted the initial location of the map to be centered around the entire USA instead of just Isla Vista

Here are screenshots of iOS:

<img width="378" alt="Screenshot 2023-11-30 at 2 52 53 PM" src="https://github.com/CS-Capstone-Team-4-Terawe/GeoNewsFinder4/assets/75236585/1592a982-946d-47f2-b059-2e2de111a185">

![ezgif com-video-to-gif](https://github.com/CS-Capstone-Team-4-Terawe/GeoNewsFinder4/assets/75236585/96edf164-9219-4db2-8944-7a9a679c056c)


# Testing

Tested on physical devices with both platforms Android and iOS. Hot spots correctly display the same size despite zooming in and out of map. Ensured that hot spots are tappable and can have an event response (in this case show up modal)