### PR TITLE
linked news api calls to hotspot

### DIFF
--- a/GeoNewsFinder4/components/BottomSheet.js
+++ b/GeoNewsFinder4/components/BottomSheet.js
@@ -3,14 +3,14 @@ import { View, Text, TouchableOpacity, StyleSheet, FlatList, Image } from 'react
 import { Card } from 'react-native-elements';
 import { useNavigation } from '@react-navigation/native';
 
-const BottomSheet = ({ closeModal }) => {
+const BottomSheet = ({ closeModal, hotspotId }) => {
 
     const navigation = useNavigation();
 
     const [newsData, setData] = useState([]);
 
     const getAPIdata = async () => {
-      const topic = 'Apple';
+      const topic = hotspotId || 'Apple';
       const searchIn = 'description';   // parameters: title, description, content
       const domains = '';               // example: bbc.co.uk,techcrunch.com
       const excludeDomains = '';
@@ -36,9 +36,11 @@ const BottomSheet = ({ closeModal }) => {
       result = await result.json();
       setData(result.articles);
     }
-    useEffect (() => {
-      getAPIdata();
-    }, []);
+    useEffect(() => {
+      if(hotspotId) {
+        getAPIdata();
+      }
+    }, [hotspotId]);
     console.log(newsData);
 
   return (

--- a/GeoNewsFinder4/screens/MapViewScreen.js
+++ b/GeoNewsFinder4/screens/MapViewScreen.js
@@ -23,6 +23,8 @@ const INITIAL_LOCATION = {
 const MapViewScreen = () => {
   const [isModalVisible, setModalVisible] = useState(false);
 
+  const [selectedHotspotId, setSelectedHotspotId] = useState(null);
+
   const [hotspots, setHotspots] = useState([
     {
       _id: 'san diego',
@@ -47,7 +49,8 @@ const MapViewScreen = () => {
     }
   ]);
 
-  const toggleModal = () => {
+  const toggleModal = (hotspotId) => {
+    setSelectedHotspotId(hotspotId);
     setModalVisible(!isModalVisible);
   };
 
@@ -70,7 +73,7 @@ const MapViewScreen = () => {
               );
   
               if (distance <= hotspot.radius) {
-                toggleModal();
+                toggleModal(hotspot._id);
               }
           })
       }}
@@ -97,7 +100,7 @@ const MapViewScreen = () => {
         visible={isModalVisible}
         onRequestClose={toggleModal}
       >
-        <BottomSheet closeModal={toggleModal} />
+        <BottomSheet closeModal={toggleModal} hotspotId={selectedHotspotId} />
       </Modal>
     </View>
   );


### PR DESCRIPTION
Issue: [https://trello.com/c/nlRm1RY2](https://trello.com/c/nlRm1RY2)

When the hotspot radius is clicked, the location data is passed to the news API so that the search articles can be displayed on the modal screen.

San Diego hotspot:
<img height="500" alt="Screen Shot 2022-05-15 at 4 25 30 PM" src="https://github.com/CS-Capstone-Team-4-Terawe/GeoNewsFinder4/assets/77522068/222b2b5b-14db-4c1e-94c4-5afaf9d73289">  <img height="500" alt="Screen Shot 2022-05-15 at 4 25 30 PM" src="https://github.com/CS-Capstone-Team-4-Terawe/GeoNewsFinder4/assets/77522068/101ecb69-5ce6-43b1-bb59-9a4cc70cb01a">

NYC hotspot:
<img height="500" alt="Screen Shot 2022-05-15 at 4 25 30 PM" src="https://github.com/CS-Capstone-Team-4-Terawe/GeoNewsFinder4/assets/77522068/e110f13c-3bb5-4b24-adc0-8dad0a64a7fc">  <img height="500" alt="Screen Shot 2022-05-15 at 4 25 30 PM" src="https://github.com/CS-Capstone-Team-4-Terawe/GeoNewsFinder4/assets/77522068/14be5028-d237-4119-b164-228bfe3ab683">