### PR TITLE
article object is passed to article synopsis view now

### DIFF
--- a/GeoNewsFinder4/components/BottomSheet.js
+++ b/GeoNewsFinder4/components/BottomSheet.js
@@ -56,7 +56,7 @@ const BottomSheet = ({ closeModal, hotspotId }) => {
         renderItem={({ item }) => (
           <TouchableOpacity 
             onPress={ () => {
-              navigation.navigate('ArticlePage', {name: item.title});
+              navigation.navigate('ArticlePage', {name: item});
               closeModal();
             }} 
             style={styles.container2}>

--- a/GeoNewsFinder4/screens/ArticleSynopsisViewScreen.js
+++ b/GeoNewsFinder4/screens/ArticleSynopsisViewScreen.js
@@ -1,11 +1,11 @@
 import React from 'react';
-import { View, StyleSheet, useWindowDimensions} from 'react-native';
+import { View, StyleSheet, useWindowDimensions, Text, Image } from 'react-native';
 import { TabView, SceneMap, TabBar } from 'react-native-tab-view';
 import OverviewRoute from '../components/Overview';
 import AskGPTRoute from '../components/AskGPT';
 import RelatedArticlesRoute from '../components/RelatedArticles';
 
-function ArticleSynopsisView() {
+function ArticleSynopsisView( {route, navigation} ) {
   const renderScene = SceneMap({
     first: OverviewRoute,
     second: AskGPTRoute,
@@ -29,9 +29,14 @@ function ArticleSynopsisView() {
       labelStyle={styles.tabBarLabel}
     />
   );
+  console.log(route.params.name.title);
 
   return (
     <View style={styles.container}>
+      <View style={styles.title}>
+        <Text>{route.params.name.title}</Text>
+        <Image source={{ uri: route.params.name.urlToImage }} style={styles.image} />
+      </View>
       <View style={styles.tabViewContainer}>
         <TabView
           navigationState={{ index, routes }}
@@ -45,6 +50,12 @@ function ArticleSynopsisView() {
   );
 }
 const styles = StyleSheet.create({
+    title: {
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      height: '35%',
+    },
     container: {
       flex: 1,
       backgroundColor: '#fff',
@@ -68,6 +79,11 @@ const styles = StyleSheet.create({
     tabBarLabel: {
       fontSize: 12,
     },
+    image: {
+      width: '100%',
+      height: 150,
+      borderRadius: 8,
+    }
   });
 
 export default ArticleSynopsisView;


### PR DESCRIPTION
Issue: [https://trello.com/c/XCnHErqG](https://trello.com/c/XCnHErqG)

When clicking on a article tile, the article is sent to the following page and can display the title and image corresponding to that article.

<img height="600" alt="Screen Shot 2022-05-15 at 4 25 30 PM" src="https://github.com/CS-Capstone-Team-4-Terawe/GeoNewsFinder4/assets/77522068/a410341b-764e-4e7f-95ce-0b50460ec8a8">  <img height="600" alt="Screen Shot 2022-05-15 at 4 25 30 PM" src="https://github.com/CS-Capstone-Team-4-Terawe/GeoNewsFinder4/assets/77522068/de2e9888-42e5-410b-bbfc-94db87f06b46"><br>
