### PR TITLE
Fixed text getting cut off

### DIFF
--- a/GeoNewsFinder4/components/SearchBar.js
+++ b/GeoNewsFinder4/components/SearchBar.js
@@ -36,7 +36,7 @@ const SearchBar = ({ onSearchSubmit }) => {
       height: 45,
       width: 300,
       margin: 0,
-      padding: 20,
+      paddingLeft: 20,
       fontSize: 17,
       borderRadius: 20,
       borderTopRightRadius: 0,


### PR DESCRIPTION
Made the padding in search bar only for left side so that text doesn't get cut off.

<img width="385" alt="image" src="https://github.com/CS-Capstone-Team-4-Terawe/GeoNewsFinder4/assets/80609596/f7b43e62-e679-4e5f-95ba-405d62b06997">
