### PR TITLE
related articles display (doesnt display current article)

### DIFF
--- a/GeoNewsFinder4/components/AskGPT.js
+++ b/GeoNewsFinder4/components/AskGPT.js
@@ -8,35 +8,34 @@ import { useRoute } from '@react-navigation/native';
 const AskGPTRoute = () => {
   const scrollViewRef = useRef();
   const route = useRoute();
-  const articleUrl = route.params?.articleUrl; // Retrieve the articleUrl passed as a parameter
+  const articleUrl = route.params?.articleUrl;
   const [GPTQuestion, setQuestion] = useState('');
   const [error, setError] = useState(null);
-  // Updated: Use state to store chat history
   const [chatHistory, setChatHistory] = useState([]);
+
+  const resetChatHistory = () => {
+    setQuestion('');
+    setChatHistory([]);
+  };
 
   const askGPT = async () => {
     setError(null);
     let question = GPTQuestion.trim();
 
     if (question) {
-      // Add question to chat history
       setChatHistory(currentHistory => [...currentHistory, { type: 'question', content: question }]);
 
       try {
-        console.log("API Gateway try");
         const apiUrl = 'https://etrpbogfh3.execute-api.us-west-1.amazonaws.com/testDB';
         const response = await axios.post(apiUrl, {
           "article_url": articleUrl,         
           "isQuestion": true,
           "question": question
         });
-        console.log("API Gateway try after 2");
 
         if (response.data) {
           const responseBody = JSON.parse(response.data.body);
-          // Add answer to chat history
           setChatHistory(currentHistory => [...currentHistory, { type: 'answer', content: responseBody.responseContent }]);
-          console.log(responseBody.responseContent);
         } else {
           setError("Received unexpected response from the server");
         }
@@ -51,19 +50,17 @@ const AskGPTRoute = () => {
   };
 
   const askQuestion = async () => {
-    console.log("Enter ask question");
-    setQuestion(''); // Consider keeping the question in the input until a new one is typed
+    setQuestion(''); 
     await askGPT();
   };
 
   
   useEffect(() => {
-    // Delay scrolling to ensure the newly added message is rendered.
     const timer = setTimeout(() => {
       scrollViewRef.current.scrollToEnd({ animated: true });
-    }, 30); // Adjust the delay as needed, 100ms is usually enough
+    }, 30); 
   
-    return () => clearTimeout(timer); // Clean up the timer when the component unmounts or before re-running the effect
+    return () => clearTimeout(timer); 
   }, [chatHistory]);
 
   useEffect(() => {
@@ -80,22 +77,24 @@ const AskGPTRoute = () => {
       keyboardDidShowListener.remove();
       keyboardDidHideListener.remove();
     };
-  }, []); // This effect depends on no changing dependencies and thus runs once on mount.
+  }, []); 
   
   const _keyboardDidShow = () => {
     scrollViewRef.current.scrollToEnd({ animated: true });
   };
   
   const _keyboardDidHide = () => {
-    // Optional: Handle any action on keyboard hide if necessary
   };
+
+  useEffect(() => {
+    resetChatHistory();
+  }, [route]);
 
   return (
     <View style={styles.outerContainer}>
       <ScrollView
         ref={scrollViewRef}
         contentContainerStyle={[styles.scrollContainer, chatHistory.length > 0 ? {} : styles.flexGrow]}
-        // automaticallyAdjustKeyboardInsets={true}
       >
         <View style={styles.chatTextView}>
           {chatHistory.map((msg, index) => (
@@ -138,11 +137,11 @@ const AskGPTRoute = () => {
 const styles = StyleSheet.create({
   outerContainer: {
     flex: 1,
-    justifyContent: 'space-between', // This ensures the search container stays at the bottom
+    justifyContent: 'space-between', 
     backgroundColor: '#fff',
   },
   scrollContainer: {
-    paddingBottom: 10, // Adjust this value based on the height of your searchContainer
+    paddingBottom: 10,
   },
   container: {
     flex: 1,

--- a/GeoNewsFinder4/components/BottomSheet.js
+++ b/GeoNewsFinder4/components/BottomSheet.js
@@ -9,17 +9,6 @@ const BottomSheet = ({ closeModal, hotspotId, groupedLocations }) => {
     const navigation = useNavigation();
     const articles = groupedLocations[hotspotId] || [];
 
-    // const [newsData, setData] = useState([]);
-
-    // useEffect(() => {
-    //   const fetchData = async () => {
-    //     if (hotspotId) {
-    //       await getAPIdata(hotspotId, setData);
-    //     }
-    //   };
-    //   fetchData();
-    // }, [hotspotId]);  
-
   return (
     <View style={styles.bottomSheetContainer}>
       <TouchableOpacity onPress={closeModal} style={styles.closeButton}>

--- a/GeoNewsFinder4/components/BottomSheet.js
+++ b/GeoNewsFinder4/components/BottomSheet.js
@@ -33,7 +33,7 @@ const BottomSheet = ({ closeModal, hotspotId, groupedLocations }) => {
         renderItem={({ item }) => (
           <TouchableOpacity 
             onPress={ () => {
-              navigation.navigate('ArticlePage', {name: item, hotspot: hotspotId, articleUrl: item.url});
+              navigation.navigate('ArticlePage', {name: item, hotspot: hotspotId, articleUrl: item.url, searchArticles: articles});
               closeModal();
             }} 
             style={styles.container2}>

--- a/GeoNewsFinder4/components/Overview.js
+++ b/GeoNewsFinder4/components/Overview.js
@@ -1,28 +1,18 @@
 import React, { useState, useEffect } from 'react';
-import { View, StyleSheet, Text, Button, ScrollView } from 'react-native';
-import { ask, summarizeArticle, NewsArticle } from '../utils/openAIGPTFunctions.js'; 
+import { View, StyleSheet, Text, ScrollView } from 'react-native';
 import axios from 'axios';
 import { useRoute } from '@react-navigation/native';
 
-let news_article = new NewsArticle(
-  "A potential Las Vegas workers strike could throw a wrench in the upcoming F1 race",
-  ["Hernandez", "Joe"],
-  "Monday, November 6, 2023 • 5:00 AM EST",
-  "Tens of thousands of Las Vegas hospitality workers may walk off the job this Friday if their union is unable to reach a contract deal with the casinos, hotels and restaurants that employ them. What could possibly be the largest hospitality worker strike in U.S. history comes as the city is being transformed into a giant racetrack ahead of the Formula 1 Las Vegas Grand Prix scheduled to take place later this month — the first time the sport is returning to the entertainment capital in more than four decades. The Culinary and Bartenders Union said 35,000 of its members at 18 properties would go on strike the morning of Nov. 10 if no deal was reached with MGM Resorts, Caesars Entertainment and Wynn Resorts. The labor group said it had been negotiating with the hospitality giants in good faith for seven months — and working under an expired contract since Sept. 15 — but believed its workers deserved more than what the companies were offering. Their current proposal on the table is historic, but it's not enough and workers deserve to have record contracts - especially after these giant corporations are enjoying their record profits, Culinary Union secretary-treasurer Ted Pappageorge said in a statement. Related Story: Formula 1's new fandom; plus, Christian Horner is always on the offense Michael Weaver, chief communications and marketing officer for Wynn Resorts, said the company 'will save our comments regarding negotiations for the bargaining table.' MGM Resorts and Caesars Entertainment did not immediately reply to NPR's request for comment. Complicating the possibility of a massive strike on the Las Vegas Strip is the Formula 1 grand prix weekend scheduled to begin on Nov. 16 and expected to pack the city with tourists. Formula 1 announced last year that it would be adding the Las Vegas race — in addition to contests already held in Miami and Austin — as the sport sees surging popularity across the U.S. Two Formula 1 races were hosted in Las Vegas in 1981 and 1982, but this year's track will be the first one to incorporate the vistas of the city's iconic Strip, with the circuit passing landmarks such as Caesars Palace, the Bellagio and the Venetian. The Culinary Union is asking race attendees not to cross any picket or strike lines and to refrain from patronizing hotels and casinos where there is a labor dispute. Formula 1 did not immediately reply to NPR's request for comment. Race organizers have also been dealing with some local backlash over how Formula 1 has been preparing for the grand prix — what a Las Vegas Review-Journal columnist called the city's 'love-hate relationship' with the race. While many cheered the boost to the local economy, others have complained about some of the work being done. Formula 1 said it added visual barriers to pedestrian walkways for safety reasons, though some annoyed residents tore them down. Others have complained about trees being chopped down at the Bellagio and construction-related traffic jams"
-  // "Tens of thousands of Las Vegas hospitality workers ...  the Bellagio and construction-related traffic jams"
-);
-
 const OverviewRoute = () => {
   const route = useRoute();
-  const articleUrl = route.params?.articleUrl; // Retrieve the articleUrl passed as a parameter
+  const articleUrl = route.params?.articleUrl; 
 	const [error, setError] = useState(null);
   const [summary, setSummary] = useState('Loading...');
     useEffect(() => {
       const fetchSummary = async () => {
           setError(null);
           try {
-              // Replace this URL with your actual API Gateway URL
-              console.log("API Gateway try");
+              setSummary('Loading...');
               const apiUrl = 'https://5vfzo8wbu2.execute-api.us-west-1.amazonaws.com/testDBGPT1';
               const response = await axios.post(apiUrl, {
                 "article_url": articleUrl,
@@ -30,35 +20,22 @@ const OverviewRoute = () => {
                 "question": "There is no question"
                 }
               );
-              console.log("API Gateway try after 2");
-              // console.log(response.data)
               if (response.data) {
-                // Assuming your API returns the summary inside the nested body as a JSON string
-                // First, parse the outer JSON if not already an object
                 const outerBody = typeof response.data.body === 'string' ? JSON.parse(response.data.body) : response.data.body;
-                // Then, parse the inner JSON to get the actual content object
                 const responseBody = typeof outerBody.body === 'string' ? JSON.parse(outerBody.body) : outerBody.body;
-                
-                // console.log(responseBody); // This should now log the parsed object
-            
-                // Now you can access responseContent directly
                 const responseContent = responseBody.responseContent;
-                console.log(responseContent); // This should log the actual content string
-            
                 setSummary(responseContent);
               } else {
-                  // Handle case where API response does not contain expected data
                   setError("Received unexpected response from the server");
               }
           } catch(e) {
-              // console.log("big oopsie error log");
               setError(e?.message || "Something went wrong");
           }
       };
   
       fetchSummary();
-  }, []);
-  
+  }, [articleUrl]);
+
   return (
     <View style={styles.overviewContainer}>
       <ScrollView style={styles.scrollView} contentContainerStyle={styles.contentContainer}>

--- a/GeoNewsFinder4/components/RelatedArticles.js
+++ b/GeoNewsFinder4/components/RelatedArticles.js
@@ -2,18 +2,19 @@ import { React, useEffect, useState } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet, FlatList, Image } from 'react-native';
 import { Card } from 'react-native-elements';
 import { useRoute } from '@react-navigation/native';
+import { useNavigation } from '@react-navigation/native';
 
 const RelatedArticlesRoute = ({ }) => {
 
   const route = useRoute();
+  console.log("route:", route);
+  const navigation = useNavigation();
   const articles = route.params?.searchArticles;
   const articleURL = route.params?.articleUrl;
+  console.log("articles", articles);
   var index = articles.findIndex(obj => obj.url==articleURL);
 
   const relatedArticles = articles.slice(0, index).concat(articles.slice(index+1));
-  console.log("articles", articles);
-  console.log(index);
-  console.log("related", relatedArticles);
 
   return (
     <View style={styles.relatedArticlesContainer}>
@@ -23,17 +24,16 @@ const RelatedArticlesRoute = ({ }) => {
         keyExtractor={(item) => item.url}
         numColumns={2}
         renderItem={({ item }) => (
-          // <TouchableOpacity 
-          //   onPress={ () => {
-          //     navigation.navigate('ArticlePage', {name: item, hotspot: hotspotId, articleUrl: item.url});
-          //     closeModal();
-          //   }} 
-            // style={styles.container2}>
+          <TouchableOpacity 
+            onPress={ () => {
+              navigation.navigate('ArticlePage', {name: item, hotspot: route.params?.hotspot, articleUrl: item.url, searchArticles: articles});
+            }} 
+            style={styles.container2}>
             <Card containerStyle={styles.card}>
               <Image source={{ uri: item.urlToImage }} style={styles.image} />
               <Text style={styles.title}>{item.title}</Text>
             </Card>
-          // </TouchableOpacity>
+          </TouchableOpacity>
         ) }
       />
     </View>

--- a/GeoNewsFinder4/components/RelatedArticles.js
+++ b/GeoNewsFinder4/components/RelatedArticles.js
@@ -1,33 +1,39 @@
 import { React, useEffect, useState } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet, FlatList, Image } from 'react-native';
 import { Card } from 'react-native-elements';
-import getAPIdata from '../utils/getAPIdata';
+import { useRoute } from '@react-navigation/native';
 
-const RelatedArticlesRoute = ({ route }) => {
+const RelatedArticlesRoute = ({ }) => {
 
-  const [newsData, setData] = useState([]);
-  useEffect(() => {
-    const fetchData = async () => {
-      if (route.params.hotspot) {
-        await getAPIdata(route.params.hotspot, setData);
-      }
-    };
-    fetchData();
-  }, [route.params.hotspot]);
+  const route = useRoute();
+  const articles = route.params?.searchArticles;
+  const articleURL = route.params?.articleUrl;
+  var index = articles.findIndex(obj => obj.url==articleURL);
+
+  const relatedArticles = articles.slice(0, index).concat(articles.slice(index+1));
+  console.log("articles", articles);
+  console.log(index);
+  console.log("related", relatedArticles);
 
   return (
     <View style={styles.relatedArticlesContainer}>
       <FlatList
         style={styles.container2}
-        data={newsData}
+        data={relatedArticles}
         keyExtractor={(item) => item.url}
         numColumns={2}
         renderItem={({ item }) => (
-          <Card containerStyle={styles.card}>
-            <Image source={{ uri: item.urlToImage }} style={styles.image} />
-            <Text style={styles.title}>{item.title}</Text>
-          </Card>
-          // TODO: when clicked, open the article in a chrome/safari
+          // <TouchableOpacity 
+          //   onPress={ () => {
+          //     navigation.navigate('ArticlePage', {name: item, hotspot: hotspotId, articleUrl: item.url});
+          //     closeModal();
+          //   }} 
+            // style={styles.container2}>
+            <Card containerStyle={styles.card}>
+              <Image source={{ uri: item.urlToImage }} style={styles.image} />
+              <Text style={styles.title}>{item.title}</Text>
+            </Card>
+          // </TouchableOpacity>
         ) }
       />
     </View>

--- a/GeoNewsFinder4/components/RelatedArticles.js
+++ b/GeoNewsFinder4/components/RelatedArticles.js
@@ -7,11 +7,9 @@ import { useNavigation } from '@react-navigation/native';
 const RelatedArticlesRoute = ({ }) => {
 
   const route = useRoute();
-  console.log("route:", route);
   const navigation = useNavigation();
   const articles = route.params?.searchArticles;
   const articleURL = route.params?.articleUrl;
-  console.log("articles", articles);
   var index = articles.findIndex(obj => obj.url==articleURL);
 
   const relatedArticles = articles.slice(0, index).concat(articles.slice(index+1));

--- a/GeoNewsFinder4/screens/ArticleSynopsisViewScreen.js
+++ b/GeoNewsFinder4/screens/ArticleSynopsisViewScreen.js
@@ -1,11 +1,11 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { View, StyleSheet, useWindowDimensions, Text, Image, KeyboardAvoidingView, Platform } from 'react-native';
-import { TabView, SceneMap, TabBar } from 'react-native-tab-view';
+import { TabView, TabBar } from 'react-native-tab-view';
 import OverviewRoute from '../components/Overview';
 import AskGPTRoute from '../components/AskGPT';
 import RelatedArticlesRoute from '../components/RelatedArticles';
 
-function ArticleSynopsisView( {route, navigation} ) {
+function ArticleSynopsisView( {route} ) {
   const layout = useWindowDimensions();
 
   const [index, setIndex] = React.useState(0);
@@ -16,10 +16,9 @@ function ArticleSynopsisView( {route, navigation} ) {
     { key: 'third', title: 'Related' },
   ]);
 
-  // Memoize the tab components to prevent re-creation
   const tabComponents = React.useMemo(() => ({
-    first: <OverviewRoute />,
-    second: <AskGPTRoute />,
+    first: <OverviewRoute route={route} />,
+    second: <AskGPTRoute route={route}/>,
     third: <RelatedArticlesRoute route={route} />,
   }), [route]);
 
@@ -42,7 +41,6 @@ function ArticleSynopsisView( {route, navigation} ) {
   );
 
   useEffect(() => {
-    // Reset the tab index to the first tab when the route changes
     setIndex(0);
   }, [route]);
 

--- a/GeoNewsFinder4/screens/ArticleSynopsisViewScreen.js
+++ b/GeoNewsFinder4/screens/ArticleSynopsisViewScreen.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { View, StyleSheet, useWindowDimensions, Text, Image, KeyboardAvoidingView, Platform } from 'react-native';
 import { TabView, SceneMap, TabBar } from 'react-native-tab-view';
 import OverviewRoute from '../components/Overview';
@@ -40,6 +40,11 @@ function ArticleSynopsisView( {route, navigation} ) {
       )}
     />
   );
+
+  useEffect(() => {
+    // Reset the tab index to the first tab when the route changes
+    setIndex(0);
+  }, [route]);
 
   return (
     <KeyboardAvoidingView 


### PR DESCRIPTION
Related Articles tab now shows related articles based off original bottom sheet screen after clicking on a hotspot. The current article is excluded from list of related articles.

When clicking on a new article from the related articles page, the user will be directed to the Overview Tab with the summary and chat bot reset.

<img height="600" alt="Screen Shot 2022-05-15 at 4 25 30 PM" src="https://github.com/CS-Capstone-Team-4-Terawe/GeoNewsFinder4/assets/77522068/0b33f8b9-8e00-4c80-9c68-082615e93b74"> <img height="600" alt="Screen Shot 2022-05-15 at 4 25 30 PM" src="https://github.com/CS-Capstone-Team-4-Terawe/GeoNewsFinder4/assets/77522068/d31b94e5-76b9-493f-be8a-be3db226e591">