### PR TITLE
ju- split up preferences page and custom city

### DIFF
--- a/GeoNewsFinder4/App.js
+++ b/GeoNewsFinder4/App.js
@@ -7,6 +7,10 @@ import ArticleSynopsisView from './screens/ArticleSynopsisViewScreen';
 import LoginView from './screens/LoginViewScreen';
 import ProfileView from './screens/ProfileViewScreen';
 import UserPreferencesView from './screens/UserPreferencesViewScreen';
+import UserPrefView1 from './screens/UserPrefViewScreen1';
+import UserPrefView2 from './screens/UserPrefViewScreen2';
+import UserPrefView3 from './screens/UserPrefViewScreen3';
+import UserPrefView4 from './screens/UserPrefViewScreen4';
 import SignUpView from './screens/SignUpViewScreen';
 import ConfirmView from './screens/ConfirmViewScreen';
 import { Amplify } from 'aws-amplify';
@@ -69,15 +73,45 @@ function App() {
             }}
           />
           <Stack.Screen
-            name='UserPreferencesView'
-            component={ UserPreferencesView }
+            name='UserPrefView1'
+            component={ UserPrefView1 }
             options={{
               title: '',
               headerShown: true,
               headerTintColor: 'black',
               headerStyle: { backgroundColor: 'white' },
             }}
-          />
+          />    
+          <Stack.Screen
+            name='UserPrefView2'
+            component={ UserPrefView2 }
+            options={{
+              title: '',
+              headerShown: true,
+              headerTintColor: 'black',
+              headerStyle: { backgroundColor: 'white' },
+            }}
+          /> 
+          <Stack.Screen
+            name='UserPrefView3'
+            component={ UserPrefView3 }
+            options={{
+              title: '',
+              headerShown: true,
+              headerTintColor: 'black',
+              headerStyle: { backgroundColor: 'white' },
+            }}
+          />    
+          <Stack.Screen
+            name='UserPrefView4'
+            component={ UserPrefView4 }
+            options={{
+              title: '',
+              headerShown: true,
+              headerTintColor: 'black',
+              headerStyle: { backgroundColor: 'white' },
+            }}
+          />          
           <Stack.Screen
             name='SignUpView'
             component={ SignUpView }

--- a/GeoNewsFinder4/package-lock.json
+++ b/GeoNewsFinder4/package-lock.json
@@ -36,6 +36,7 @@
         "react-native-datepicker": "^1.7.2",
         "react-native-elements": "^3.4.3",
         "react-native-gesture-handler": "~2.12.0",
+        "react-native-google-places-autocomplete": "^2.5.6",
         "react-native-maps": "1.7.1",
         "react-native-picker-select": "^9.0.1",
         "react-native-reanimated": "^3.6.0",
@@ -23821,6 +23822,30 @@
       },
       "peerDependencies": {
         "react-native": ">=0.56"
+      }
+    },
+    "node_modules/react-native-google-places-autocomplete": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/react-native-google-places-autocomplete/-/react-native-google-places-autocomplete-2.5.6.tgz",
+      "integrity": "sha512-Dy7mFKyEoiNeWPLd7HUkrI/SzJYe7GST55FGtiXzXDoPs05LYHIOCPrT9qFE51COh5X8kgDKm+f7D5aMY/aMbg==",
+      "dependencies": {
+        "lodash.debounce": "^4.0.8",
+        "prop-types": "^15.7.2",
+        "qs": "~6.9.1"
+      },
+      "peerDependencies": {
+        "react-native": ">= 0.59"
+      }
+    },
+    "node_modules/react-native-google-places-autocomplete/node_modules/qs": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw==",
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/react-native-maps": {

--- a/GeoNewsFinder4/package.json
+++ b/GeoNewsFinder4/package.json
@@ -37,6 +37,7 @@
     "react-native-datepicker": "^1.7.2",
     "react-native-elements": "^3.4.3",
     "react-native-gesture-handler": "~2.12.0",
+    "react-native-google-places-autocomplete": "^2.5.6",
     "react-native-maps": "1.7.1",
     "react-native-picker-select": "^9.0.1",
     "react-native-reanimated": "^3.6.0",

--- a/GeoNewsFinder4/screens/ConfirmViewScreen.js
+++ b/GeoNewsFinder4/screens/ConfirmViewScreen.js
@@ -25,7 +25,7 @@ async function confirmSignUp() {
     const user = await Auth.signIn(email, password);
     dispatch(logIn());
     dispatch(setUser(user.attributes));
-    navigation.navigate('UserPreferencesView');
+    navigation.navigate('UserPrefView1'); // changed to first pref 
   } catch (error) {
     console.log('error confirming sign up', error);
   }

--- a/GeoNewsFinder4/screens/UserPrefViewScreen1.js
+++ b/GeoNewsFinder4/screens/UserPrefViewScreen1.js
@@ -1,0 +1,128 @@
+import React, { useState } from 'react';
+import { View, Text, TouchableOpacity, StyleSheet, ScrollView} from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+
+const UserPrefViewScreen1 = () => {
+  const navigation = useNavigation();
+  const [selectedOptions, setSelectedOptions] = useState([]);
+  const options = [
+    { id: 1, label: 'Politics', emoji: '🗳️' },
+    { id: 2, label: 'Technology', emoji: '💻' },
+    { id: 3, label: 'Sports', emoji: '⚽' },
+    { id: 4, label: 'Business', emoji: '💼' },
+    { id: 5, label: 'Science', emoji: '🔬' },
+    { id: 6, label: 'Environment', emoji: '🌍' },
+    { id: 7, label: 'Education', emoji: '📚' },
+    { id: 8, label: 'World News', emoji: '🌐' },
+    { id: 9, label: 'Fashion, Beauty & Style', emoji: '👗' },
+    { id: 10, label: 'Health', emoji: '🏥' },
+    { id: 11, label: 'Entertainment', emoji: '🎬' },
+    { id: 12, label: 'Food and Cooking', emoji: '🍔' },
+  ];
+
+const handleOptionToggle = (label) => {
+  if (selectedOptions.includes(label)) {
+    setSelectedOptions(selectedOptions.filter((selectedLabel) => selectedLabel !== label));
+  } else {
+    setSelectedOptions([...selectedOptions, label]);
+  }
+};
+
+  const handleNextPage = async () => {
+    if (selectedOptions.length >= 3) {
+      console.log(selectedOptions)
+      navigation.navigate('UserPrefView2', { selectedOptions });
+    } else {
+      alert('Please select at least 3 options');
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.questionText}>1. What news are you interested in?</Text>
+      <Text style={styles.subtitle}> Select at least 3 topics. </Text>
+      <View style={styles.optionsContainer}>
+        {options.map((option) => (
+          <TouchableOpacity
+            key={option.id}
+            style={[
+              styles.optionButton,
+              {
+                backgroundColor: selectedOptions.includes(option.label) ? 'lightblue' : 'white',
+                borderColor: selectedOptions.includes(option.label) ? 'white' : 'lightgrey',
+              },
+            ]}
+            onPress={() => handleOptionToggle(option.label)}
+          >
+            <Text style={styles.optionLabel}>
+              {option.emoji} {option.label}
+            </Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+      <TouchableOpacity
+        style={[
+          styles.arrowButton,
+          {
+            backgroundColor: selectedOptions.length >= 3 ? 'lightblue' : 'grey',
+          },
+        ]}
+        onPress={handleNextPage}
+        disabled={selectedOptions.length < 3}
+      >
+        <Text style={styles.arrowText}>Next</Text>
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flexGrow: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  questionText: {
+    marginTop: 50,
+    fontSize: 20,
+    marginBottom: 20,
+    justifyContent: 'center',
+    textAlign: 'center',
+  },
+  subtitle: {
+    fontSize: 14,
+    marginBottom: 20,
+    fontStyle: 'italic',
+    color: 'grey',
+    justifyContent: 'center',
+    textAlign: 'left',
+  },
+  optionsContainer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+    marginBottom: 20,
+  },
+  optionButton: {
+    padding: 10,
+    borderRadius: 10,
+    borderWidth: 2,
+    margin: 5,
+  },
+  optionLabel: {
+    color: 'black',
+    textAlign: 'center',
+  },
+  arrowButton: {
+    backgroundColor: 'grey',
+    padding: 10,
+    borderRadius: 10,
+    marginTop: 20,
+  },
+  arrowText: {
+    color: 'white',
+    fontSize: 20,
+  },
+});
+
+export default UserPrefViewScreen1;

--- a/GeoNewsFinder4/screens/UserPrefViewScreen2.js
+++ b/GeoNewsFinder4/screens/UserPrefViewScreen2.js
@@ -1,0 +1,135 @@
+import React, { useState } from 'react';
+import { View, StyleSheet, TouchableOpacity, Text, ScrollView  } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+
+const UserPrefViewScreen2 = ({route, navigation}) => {
+//   const navigation = useNavigation();
+//   const route = useRoute();
+  const selectedTopics = route.params?.selectedOptions;
+  const [selectedOptions, setSelectedOptions] = useState([]);
+  const options = [
+    { id: 13, label: 'Football', emoji: '⚽' },
+    { id: 14, label: 'Basketball', emoji: '🏀' },
+    { id: 15, label: 'Baseball', emoji: '⚾' },
+    { id: 16, label: 'Tennis', emoji: '🎾' },
+    { id: 17, label: 'Golf', emoji: '⛳' },
+    { id: 18, label: 'Swimming', emoji: '🏊' },
+    { id: 19, label: 'Running', emoji: '🏃' },
+    { id: 20, label: 'Cycling', emoji: '🚴' },
+    { id: 21, label: 'None', emoji: '🚫' },
+  ];
+
+  const handleOptionToggle = (label) => {
+    if (label === 'None') { // Check if "None" option is selected
+      setSelectedOptions([label]); // Select only the "None" option
+    } else {
+      if (selectedOptions.includes('None')) { // If "None" option was previously selected
+        setSelectedOptions([label]); // Select the new option only
+      } else {
+        if (selectedOptions.includes(label)) {
+          setSelectedOptions(selectedOptions.filter((selectedLabel) => selectedLabel !== label));
+        } else {
+          setSelectedOptions([...selectedOptions, label]);
+        }
+      }
+    }
+  };
+
+  const handleNextPage = async () => {
+    if (selectedOptions.length >= 1) {
+      console.log(selectedOptions)
+      navigation.navigate('UserPrefView3', { selectedTopics, selectedOptions });
+    } else {
+      alert('Please select at least 1 options');
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.questionText}>2. What sports are you interested in?</Text>
+      <Text style={styles.subtitle}> Select at least 1 sport or none. </Text>
+      <View style={styles.optionsContainer}>
+        {options.map((option) => (
+          <TouchableOpacity
+            key={option.id}
+            style={[
+              styles.optionButton,
+              {
+                backgroundColor: selectedOptions.includes(option.label) ? 'lightblue' : 'white',
+                borderColor: selectedOptions.includes(option.label) ? 'white' : 'lightgrey',
+              },
+            ]}
+            onPress={() => handleOptionToggle(option.label)}
+          >
+            <Text style={styles.optionLabel}>
+              {option.emoji} {option.label}
+            </Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+      <TouchableOpacity
+        style={[
+          styles.arrowButton,
+          {
+            backgroundColor: selectedOptions.length >= 1 ? 'lightblue' : 'grey',
+          },
+        ]}
+        onPress={handleNextPage}
+        disabled={selectedOptions.length < 1}
+      >
+        <Text style={styles.arrowText}>Next</Text>
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flexGrow: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  subtitle: {
+    fontSize: 14,
+    marginBottom: 20,
+    fontStyle: 'italic',
+    color: 'grey',
+    justifyContent: 'center',
+    textAlign: 'left',
+  },
+  questionText: {
+    marginTop: 50,
+    fontSize: 20,
+    marginBottom: 20,
+    justifyContent: 'center',
+    textAlign: 'center',
+  },
+  optionsContainer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+    marginBottom: 20,
+  },
+  optionButton: {
+    padding: 10,
+    borderRadius: 10,
+    borderWidth: 2,
+    margin: 5,
+  },
+  optionLabel: {
+    color: 'black',
+    textAlign: 'center',
+  },
+  arrowButton: {
+    backgroundColor: 'grey',
+    padding: 10,
+    borderRadius: 10,
+    marginTop: 20,
+  },
+  arrowText: {
+    color: 'white',
+    fontSize: 20,
+  },
+});
+
+export default UserPrefViewScreen2;

--- a/GeoNewsFinder4/screens/UserPrefViewScreen3.js
+++ b/GeoNewsFinder4/screens/UserPrefViewScreen3.js
@@ -1,0 +1,138 @@
+import React, { useState } from 'react';
+import { View, StyleSheet, TouchableOpacity, Text, ScrollView  } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+
+const UserPrefViewScreen3 = ({route, navigation}) => {
+//   const navigation = useNavigation();
+//   const route = useRoute();
+  const selectedTopics = route.params?.selectedTopics;
+  const selectedSports = route.params?.selectedOptions;
+  const [selectedOptions, setSelectedOptions] = useState([]);
+  const options = [
+        { id: 22, label: 'New York City', emoji: '🗽' },
+        { id: 23, label: 'Los Angeles', emoji: '🌴' },
+        { id: 24, label: 'Chicago', emoji: '🏙️' },
+        { id: 25, label: 'Houston', emoji: '🤠' },
+        { id: 26, label: 'Phoenix', emoji: '🌵' },
+        { id: 27, label: 'Philadelphia', emoji: '🔔' },
+        { id: 28, label: 'San Antonio', emoji: '🤠' },
+        { id: 29, label: 'San Diego', emoji: '🌴' },
+        { id: 30, label: 'Dallas', emoji: '🤠' },
+        { id: 31, label: 'San Francisco', emoji: '🌉' },
+        { id: 32, label: 'Austin', emoji: '🎸' },
+        { id: 33, label: 'Seattle', emoji: '🌧️' },
+        { id: 34, label: 'Miami', emoji: '🌴' },
+        { id: 35, label: 'Denver', emoji: '🏔️' },
+        { id: 36, label: 'London', emoji: '🇬🇧' },
+        { id: 37, label: 'Paris', emoji: '🗼' },
+        { id: 38, label: 'Tokyo', emoji: '🗼' },
+        { id: 39, label: 'Beijing', emoji: '🏯' },
+        { id: 40, label: 'Sydney', emoji: '🐨' },
+  ];
+
+const handleOptionToggle = (label) => {
+  if (selectedOptions.includes(label)) {
+    setSelectedOptions(selectedOptions.filter((selectedLabel) => selectedLabel !== label));
+  } else {
+    setSelectedOptions([...selectedOptions, label]);
+  }
+};
+
+  const handleNextPage = async () => {
+    if (selectedOptions.length >= 1) {
+      console.log(selectedOptions)
+      navigation.navigate('UserPrefView4', { selectedTopics, selectedSports, selectedOptions });
+    } else {
+      alert('Please select at least 1 option');
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.questionText}>3. What cities are you interested in? </Text>
+      <Text style={styles.subtitle}> Select at least 1 city. If you aren't interested in these locations, don't worry you can set specific locations in the next step. </Text>
+      <View style={styles.optionsContainer}>
+        {options.map((option) => (
+          <TouchableOpacity
+            key={option.id}
+            style={[
+              styles.optionButton,
+              {
+                backgroundColor: selectedOptions.includes(option.label) ? 'lightblue' : 'white',
+                borderColor: selectedOptions.includes(option.label) ? 'white' : 'lightgrey',
+              },
+            ]}
+            onPress={() => handleOptionToggle(option.label)}
+          >
+            <Text style={styles.optionLabel}>
+              {option.emoji} {option.label}
+            </Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+      <TouchableOpacity
+        style={[
+          styles.arrowButton,
+          {
+            backgroundColor: selectedOptions.length >= 1 ? 'lightblue' : 'grey',
+          },
+        ]}
+        onPress={handleNextPage}
+        disabled={selectedOptions.length < 1}
+      >
+        <Text style={styles.arrowText}>Next</Text>
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flexGrow: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  questionText: {
+    marginTop: 50,
+    fontSize: 20,
+    marginBottom: 20,
+    justifyContent: 'center',
+    textAlign: 'center',
+  },
+  subtitle: {
+    fontSize: 14,
+    marginBottom: 20,
+    fontStyle: 'italic',
+    color: 'grey',
+    justifyContent: 'center',
+    textAlign: 'center',
+  },
+  optionsContainer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+    marginBottom: 20,
+  },
+  optionButton: {
+    padding: 10,
+    borderRadius: 10,
+    borderWidth: 2,
+    margin: 5,
+  },
+  optionLabel: {
+    color: 'black',
+    textAlign: 'center',
+  },
+  arrowButton: {
+    backgroundColor: 'grey',
+    padding: 10,
+    borderRadius: 10,
+    marginTop: 20,
+  },
+  arrowText: {
+    color: 'white',
+    fontSize: 20,
+  },
+});
+
+export default UserPrefViewScreen3;

--- a/GeoNewsFinder4/screens/UserPrefViewScreen4.js
+++ b/GeoNewsFinder4/screens/UserPrefViewScreen4.js
@@ -1,0 +1,188 @@
+import React, { useState } from 'react';
+import { View, Text, StyleSheet, TextInput, Button, FlatList, TouchableOpacity } from 'react-native';
+import { GooglePlacesAutocomplete } from 'react-native-google-places-autocomplete';
+import { useNavigation } from '@react-navigation/native';
+import { useSelector } from 'react-redux';
+import { API } from 'aws-amplify';
+
+const UserPrefViewScreen4 = ({route, navigation}) => {
+//   const navigation = useNavigation();
+//   const route = useRoute();
+  const user = useSelector(state => state.user);
+  const selectedTopics = route.params?.selectedTopics;
+  const selectedSports = route.params?.selectedSports;
+  const selectedMajorCity = route.params?.selectedOptions;
+  const [locations, setLocations] = useState([]);
+  const [inputValue, setInputValue] = useState('');
+
+  const addLocation = (location) => {
+    if (location.trim() !== '') {
+      setLocations(prevLocations => {
+        const updatedLocations = [...prevLocations, location];
+        console.log('Locations after adding:', updatedLocations);
+        return updatedLocations;
+      });
+    }
+  };
+
+  const deleteLocation = (location) => {
+    setLocations(prevLocations => {
+      const updatedLocations = prevLocations.filter(item => item !== location);
+      console.log('Locations after deleting:', updatedLocations);
+      return updatedLocations;
+    });
+  };
+
+  const handleNextPage = async () => {
+    let selectedTopicsString = selectedTopics.join(", ");
+    let selectedSportsString = selectedSports.join(", ");
+    let selectedMajorString = selectedMajorCity.join(";");
+    let selectedCityString = locations.join("; ");
+    let combinedTopicStr = selectedTopicsString + "," + selectedSportsString;
+    let combinedLocStr = selectedCityString + "; " + selectedMajorString;
+    console.log("Combined String Topics: ", combinedTopicStr)
+    console.log("Combined String Locs: ", combinedLocStr)
+    if (locations.length >= 1) {
+        try {
+            await API.post("testAPI", "/test", {
+            body: {
+                name: user.email,
+                topicPrefs: combinedTopicStr,
+                locationPrefs: combinedLocStr,
+            }
+          });
+          navigation.navigate('ProfileView');
+        } catch (error) {
+          console.error('Error posting data:', error);
+        }
+    } else {
+      alert('Please select at least 1 location');
+    }
+  };
+
+  const renderItem = ({ item }) => (
+    <LocationItem location={item} onDelete={deleteLocation} />
+  );
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.questionText}>4. Enter Specific Locations</Text>
+      <Text style={styles.subtitle}>Input any location you care about. You must input at least 1 location. </Text>
+      <GooglePlacesAutocomplete
+        placeholder='Enter your location'
+        onPress={(data, details = null) => {
+          if (details) {
+            console.log('Entire Location:', details) // json reponse 
+            const locText = details.description; // getting the entire location
+            const parts = locText.split(',').map(item => item.trim());
+            const lastThree = parts.slice(-3).join(', ');
+            addLocation(lastThree); // adding selected to location to array of location
+          }
+        }}
+        query={{
+          key: 'AIzaSyBmxjd5M80bFcbkZsV2v5Mo8ybU2V_EV4c',
+          language: 'en',
+        }}
+        styles={autoCompleteStyles}
+        textInputProps={{
+          style: [styles.searchBox, { flex: 1 }],
+        }}
+      />
+      <FlatList
+        data={locations}
+        renderItem={renderItem}
+        keyExtractor={(item, index) => index.toString()}
+      />
+      <TouchableOpacity
+        style={[
+          styles.arrowButton,
+          {
+            backgroundColor: locations.length >= 1 ? 'lightblue' : 'grey',
+          },
+        ]}
+        onPress={handleNextPage}
+        disabled={locations.length < 1}
+      >
+        <Text style={styles.arrowText}>Next</Text>
+      </TouchableOpacity>
+    </View>
+  );
+};
+
+const LocationItem = ({ location, onDelete }) => (
+  <View style={styles.locationItem}>
+    <View style={styles.locationContainer}>
+      <Text>{location}</Text>
+    </View>
+    <TouchableOpacity onPress={() => onDelete(location)}>
+      <Text style={styles.deleteButton}>X</Text>
+    </TouchableOpacity>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 20,
+  },
+  questionText: {
+    marginTop: 50,
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginBottom: 20,
+    justifyContent: 'center',
+    textAlign: 'center',
+  },
+  subtitle: {
+    fontSize: 14,
+    marginBottom: 20,
+    fontStyle: 'italic',
+    color: 'grey',
+    justifyContent: 'center',
+    textAlign: 'left',
+  },
+  searchBox: {
+    borderWidth: 1,
+    borderColor: 'lightgrey',
+    borderRadius: 5,
+    padding: 10,
+    marginBottom: 20,
+  },
+  locationItem: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 10,
+  },
+  locationContainer: {
+    flex: 1,
+    borderRadius: 20,
+    backgroundColor: '#e3e3e3',
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+  },
+  deleteButton: {
+    marginLeft: 10,
+    fontSize: 18,
+    color: 'red',
+  },
+  arrowButton: {
+    backgroundColor: 'grey',
+    padding: 10,
+    borderRadius: 10,
+    marginTop: 20,
+    alignItems: 'center',
+  },
+  arrowText: {
+    color: 'white',
+    fontSize: 20,
+  },
+});
+
+const autoCompleteStyles = {
+  container: {
+    marginBottom: 10,
+  },
+};
+
+export default UserPrefViewScreen4;
+


### PR DESCRIPTION
In this PR, 

I split up the preferences page into 4 seperate forms 
1. Takes in topics the user are interested it. Should be able to click and unclick topics you are interested in. Must select at least 3. 
2. Takes in sports the yser are interested in. Should be able to click and unclick topics you are interested in. Must select at least 1. If you click none, then all the other clicked items should become unselected. 
3. Takes in major cities the user is interested in. Should be able to click and unlick topics you are interested in. Must select at least 1.
4. User can input specific cities they are interested in using the autocomplete api. The user should be able to select and delete location they are about. If you click the X the location should be removed. 

All the topics and sports preferences are combined into the topics for the user. All the major and minor cities are combined into locations for the user. Should be properly updated to DB in backend. 